### PR TITLE
Add username field to provider secret

### DIFF
--- a/pkg/admission/validator/secretbinding_test.go
+++ b/pkg/admission/validator/secretbinding_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/admission/validator"
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
@@ -104,8 +103,9 @@ var _ = Describe("SecretBinding validator", func() {
 			apiReader.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
 					secret := &corev1.Secret{Data: map[string][]byte{
-						onmetal.NamespaceFieldName: []byte("default"),
-						onmetal.TokenFieldName:     []byte("abcd"),
+						"namespace": []byte("default"),
+						"token":     []byte("abcd"),
+						"username":  []byte("admin"),
 					}}
 					*obj = *secret
 					return nil

--- a/pkg/apis/onmetal/validation/secret.go
+++ b/pkg/apis/onmetal/validation/secret.go
@@ -31,6 +31,9 @@ func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 	if !ok {
 		return fmt.Errorf("missing field: %s in cloud provider secret", onmetal.NamespaceFieldName)
 	}
+	if _, ok := secret.Data[onmetal.UsernameFieldName]; !ok {
+		return fmt.Errorf("missing field: %s in cloud provider secret", onmetal.UsernameFieldName)
+	}
 	errs := apivalidation.ValidateNamespaceName(string(namespace), false)
 	if len(errs) > 0 {
 		return fmt.Errorf("invalid field: %s in cloud provider secret", onmetal.NamespaceFieldName)

--- a/pkg/apis/onmetal/validation/secret_test.go
+++ b/pkg/apis/onmetal/validation/secret_test.go
@@ -15,7 +15,6 @@
 package validation
 
 import (
-	"github.com/onmetal/gardener-extension-provider-onmetal/pkg/onmetal"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -29,20 +28,34 @@ var _ = Describe("Secret validation", func() {
 				Data: data,
 			}
 			err := ValidateCloudProviderSecret(secret)
-
 			Expect(err).To(matcher)
 		},
 		Entry("should return error when the token field is missing",
-			map[string][]byte{}, HaveOccurred()),
-		Entry("should return error when the namespace field is missing",
-			map[string][]byte{}, HaveOccurred()),
-		Entry("should return an error when the namespace name is invalid",
-			map[string][]byte{onmetal.NamespaceFieldName: []byte("%foo")},
-			HaveOccurred()),
-		Entry("should return error when the namespace name is valid",
 			map[string][]byte{
-				onmetal.NamespaceFieldName: []byte("foo"),
-				onmetal.TokenFieldName:     []byte("foo"),
+				"namespace": []byte("foo"),
+				"username":  []byte("admin"),
+			}, HaveOccurred()),
+		Entry("should return error when the namespace field is missing",
+			map[string][]byte{
+				"token":    []byte("foo"),
+				"username": []byte("admin"),
+			}, HaveOccurred()),
+		Entry("should return an error when the namespace name is invalid",
+			map[string][]byte{
+				"namespace": []byte("%foo"),
+				"token":     []byte("foo"),
+				"username":  []byte("admin"),
+			}, HaveOccurred()),
+		Entry("should return an error when the username is missing",
+			map[string][]byte{
+				"namespace": []byte("foo"),
+				"token":     []byte("bar"),
+			}, HaveOccurred()),
+		Entry("should return no error if the secret is valid",
+			map[string][]byte{
+				"namespace": []byte("foo"),
+				"token":     []byte("foo"),
+				"username":  []byte("admin"),
 			},
 			Not(HaveOccurred())),
 	)

--- a/pkg/onmetal/types.go
+++ b/pkg/onmetal/types.go
@@ -49,6 +49,8 @@ const (
 	// MachineControllerManagerProviderOnmetalImageName is the name of the MachineController onmetal image.
 	MachineControllerManagerProviderOnmetalImageName = "machine-controller-manager-provider-onmetal"
 
+	// UsernameFieldName is the field in a secret where the namespace is stored at.
+	UsernameFieldName = "username"
 	// NamespaceFieldName is the field in a secret where the namespace is stored at.
 	NamespaceFieldName = "namespace"
 	// KubeConfigFieldName is containing the effective kubeconfig to access an onmetal cluster.

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -66,6 +66,10 @@ func (e *ensurer) EnsureCloudProviderSecret(ctx context.Context, gctx gcontext.G
 	if !ok {
 		return fmt.Errorf("could not mutate cloudprovider secret as %q field is missing", onmetal.NamespaceFieldName)
 	}
+	username, ok := newCloudProviderSecret.Data[onmetal.UsernameFieldName]
+	if !ok {
+		return fmt.Errorf("could not mutate cloud provider secret as %q fied is missing", onmetal.UsernameFieldName)
+	}
 
 	cluster, err := gctx.GetCluster(ctx)
 	if err != nil {
@@ -82,21 +86,21 @@ func (e *ensurer) EnsureCloudProviderSecret(ctx context.Context, gctx gcontext.G
 	}
 
 	kubeconfig := &clientcmdv1.Config{
-		CurrentContext: newCloudProviderSecret.Namespace,
+		CurrentContext: cluster.Shoot.Spec.Region,
 		Clusters: []clientcmdv1.NamedCluster{{
-			Name: newCloudProviderSecret.Namespace,
+			Name: cluster.Shoot.Spec.Region,
 		}},
 		AuthInfos: []clientcmdv1.NamedAuthInfo{{
-			Name: newCloudProviderSecret.Namespace,
+			Name: string(username),
 			AuthInfo: clientcmdv1.AuthInfo{
 				Token: string(token),
 			},
 		}},
 		Contexts: []clientcmdv1.NamedContext{{
-			Name: newCloudProviderSecret.Namespace,
+			Name: cluster.Shoot.Spec.Region,
 			Context: clientcmdv1.Context{
-				Cluster:   newCloudProviderSecret.Namespace,
-				AuthInfo:  newCloudProviderSecret.Namespace,
+				Cluster:   cluster.Shoot.Spec.Region,
+				AuthInfo:  string(username),
 				Namespace: string(namespace),
 			},
 		}},


### PR DESCRIPTION
# Proposed Changes

Add a new provider secret field containing the `username` which should be used in the infrastructure cluster.
The reason for this change is that we need the `username` in order to construct an effective kubeconfig to accessing the infrastructure.

The structure of the effective `kubeconfig` will look like the following:

```
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: <CLUSTER_CA>
    server: <API_SERVER>
  name: <REGION>
contexts:
- context:
    cluster: <REGION>
    namespace: <NAMESPACE>
    user: <USERNAME>
  name: <REGION>
current-context: <REGION>
kind: Config
preferences: {}
users:
- name: <USERNAME>
  user:
    token: <MYTOKEN>
```
