### PR TITLE
Bump golang to v1.22 and golangci-lint to v1.56.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55.2
+          version: v1.56.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/gardener-extension-provider-ironcore
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
# Proposed Changes

Bump golang to v1.22 and golangci-lint to v1.56.1.