### PR TITLE
Bump golang to 1.22.2 and update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     reviewers:
       - "ironcore-dev/integration"
+    ignore:
+      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/apiextensions-apiserver"
+      - dependency-name: "k8s.io/apimachinery"
+      - dependency-name: "k8s.io/apiserver"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "k8s.io/component-base"
+      - dependency-name: "k8s.io/kube-aggregator"
+      - dependency-name: "k8s.io/kubectl"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     reviewers:
       - "ironcore-dev/integration"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     reviewers:
       - "ironcore-dev/integration"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -38,7 +38,7 @@ exclude-labels:
 autolabeler:
   - label: 'apis'
     files:
-      - '/apis/*'
+      - '/pkg/apis/*'
   - label: 'controllers'
     files:
       - '/pkg/controller/*'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.56.1
+          version: v1.57.2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
 
 jobs:

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,7 +1,7 @@
 name: Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ jobs:
       # helm cli is needed for the controller registration generation
       - uses: azure/setup-helm@v4
         with:
-          version: 'v3.11.0'
+          version: 'v3.14.3'
       - run: make test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/gardener-extension-provider-ironcore
 
-go 1.22.1
+go 1.22.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
# Proposed Changes

- Bump golang to 1.22.2
- Ignore `k8s.io/*` deps in dependabot configuration
- Bump golangci-lint and helm version in GH workflows
