### PR TITLE
Remove failing `preStop` hook in `node-driver-registrar`

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -88,13 +88,6 @@ spec:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
         - --v=5
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - "rm -rf /registration/{{ include "csi-driver-node.provisioner" . }}-reg.sock {{ .Values.socketPath }}"
         env:
         - name: ADDRESS
           value: {{ .Values.socketPath }}


### PR DESCRIPTION
## Summary

Remove failing `preStop` lifecycle hook in `node-driver-registrar` container from `csi-driver-node` daemonset.yaml

### Details

The distroless `node-driver-registrar` image lacks `/bin/sh`, causing the `preStop` hook to consistently fail. The registrar now handles the removal of the registration socket itself (see [kubernetes-csi/node-driver-registrar#61](https://github.com/kubernetes-csi/node-driver-registrar/issues/61)), eliminating the need for the failing hook.

Reference: https://github.com/kubernetes-csi/csi-driver-host-path/issues/175
