### PR TITLE
[GEP-25] Enable Shoot cloudProfile reference as complement to cloudProfileName

### DIFF
--- a/charts/gardener-extension-admission-ironcore/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-ironcore/charts/application/templates/rbac.yaml
@@ -10,6 +10,7 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
+  - namespacedcloudprofiles
   verbs:
   - get
   - list

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -134,7 +134,8 @@ metadata:
   name: my-shoot
   namespace: my-namespace
 spec:
-  cloudProfileName: ironcore
+  cloudProfile:
+    name: ironcore
   secretBindingName: my-credentials
   region: my-region
   networking:

--- a/pkg/apis/ironcore/helper/scheme.go
+++ b/pkg/apis/ironcore/helper/scheme.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore"
 	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore/install"
@@ -65,9 +65,13 @@ func InfrastructureStatusFromRaw(raw *runtime.RawExtension) (*api.Infrastructure
 func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfileConfig, error) {
 	var cloudProfileConfig *api.CloudProfileConfig
 	if cluster != nil && cluster.CloudProfile != nil && cluster.CloudProfile.Spec.ProviderConfig != nil && cluster.CloudProfile.Spec.ProviderConfig.Raw != nil {
+		cloudProfileSpecifier := fmt.Sprintf("CloudProfile %q", k8sclient.ObjectKeyFromObject(cluster.CloudProfile))
+		if cluster.Shoot != nil && cluster.Shoot.Spec.CloudProfile != nil {
+			cloudProfileSpecifier = fmt.Sprintf("%s '%s/%s'", cluster.Shoot.Spec.CloudProfile.Kind, cluster.Shoot.Namespace, cluster.Shoot.Spec.CloudProfile.Name)
+		}
 		cloudProfileConfig = &api.CloudProfileConfig{}
 		if _, _, err := decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
-			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", client.ObjectKeyFromObject(cluster.CloudProfile), err)
+			return nil, fmt.Errorf("could not decode providerConfig of %s: %w", cloudProfileSpecifier, err)
 		}
 	}
 	return cloudProfileConfig, nil


### PR DESCRIPTION
# Proposed Changes

- Enable support for the field `shoot.Spec.CloudProfile` alongside `shoot.Spec.CloudProfileName` and enable the future use of `NamespacedCloudProfile`s.

Related to https://github.com/gardener/gardener/issues/9504