### PR TITLE
Create default `NetworkPolicy` in infrastructure controller

### DIFF
--- a/pkg/apis/ironcore/types_infrastructure.go
+++ b/pkg/apis/ironcore/types_infrastructure.go
@@ -21,6 +21,8 @@ type InfrastructureConfig struct {
 	// NATPortsPerNetworkInterface defines the minimum number of ports per network interface the NAT gateway should use.
 	// Has to be a power of 2. If empty, 2048 is the default.
 	NATPortsPerNetworkInterface *int32
+	//NetworkPolicy is reference to the NetworkPolicy to use for the Shoot creation.
+	NetworkPolicyRef *commonv1alpha1.LocalUIDReference
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -35,4 +37,6 @@ type InfrastructureStatus struct {
 	NATGatewayRef commonv1alpha1.LocalUIDReference
 	// PrefixRef is the reference to the Prefix used
 	PrefixRef commonv1alpha1.LocalUIDReference
+	//NetworkPolicy is reference to the NetworkPolicy defined
+	NetworkPolicyRef commonv1alpha1.LocalUIDReference
 }

--- a/pkg/apis/ironcore/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/ironcore/v1alpha1/types_infrastructure.go
@@ -21,6 +21,8 @@ type InfrastructureConfig struct {
 	// NATPortsPerNetworkInterface defines the minimum number of ports per network interface the NAT gateway should use.
 	// Has to be a power of 2. If empty, 2048 is the default.
 	NATPortsPerNetworkInterface *int32 `json:"natPortsPerNetworkInterface,omitempty"`
+	//NetworkPolicy is reference to the NetworkPolicy to use for the Shoot creation.
+	NetworkPolicyRef *commonv1alpha1.LocalUIDReference `json:"networkPolicyRef,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -35,4 +37,6 @@ type InfrastructureStatus struct {
 	NATGatewayRef commonv1alpha1.LocalUIDReference `json:"natGatewayRef,omitempty"`
 	// PrefixRef is the reference to the Prefix used
 	PrefixRef commonv1alpha1.LocalUIDReference `json:"prefixRef,omitempty"`
+	//NetworkPolicy is reference to the NetworkPolicy defined
+	NetworkPolicyRef commonv1alpha1.LocalUIDReference `json:"networkPolicyRef,omitempty"`
 }

--- a/pkg/apis/ironcore/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/ironcore/v1alpha1/zz_generated.conversion.go
@@ -12,6 +12,7 @@ import (
 	unsafe "unsafe"
 
 	ironcore "github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore"
+	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -218,6 +219,7 @@ func Convert_ironcore_ControlPlaneConfig_To_v1alpha1_ControlPlaneConfig(in *iron
 func autoConvert_v1alpha1_InfrastructureConfig_To_ironcore_InfrastructureConfig(in *InfrastructureConfig, out *ironcore.InfrastructureConfig, s conversion.Scope) error {
 	out.NetworkRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.NetworkRef))
 	out.NATPortsPerNetworkInterface = (*int32)(unsafe.Pointer(in.NATPortsPerNetworkInterface))
+	out.NetworkPolicyRef = (*commonv1alpha1.LocalUIDReference)(unsafe.Pointer(in.NetworkPolicyRef))
 	return nil
 }
 
@@ -229,6 +231,7 @@ func Convert_v1alpha1_InfrastructureConfig_To_ironcore_InfrastructureConfig(in *
 func autoConvert_ironcore_InfrastructureConfig_To_v1alpha1_InfrastructureConfig(in *ironcore.InfrastructureConfig, out *InfrastructureConfig, s conversion.Scope) error {
 	out.NetworkRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.NetworkRef))
 	out.NATPortsPerNetworkInterface = (*int32)(unsafe.Pointer(in.NATPortsPerNetworkInterface))
+	out.NetworkPolicyRef = (*commonv1alpha1.LocalUIDReference)(unsafe.Pointer(in.NetworkPolicyRef))
 	return nil
 }
 
@@ -241,6 +244,7 @@ func autoConvert_v1alpha1_InfrastructureStatus_To_ironcore_InfrastructureStatus(
 	out.NetworkRef = in.NetworkRef
 	out.NATGatewayRef = in.NATGatewayRef
 	out.PrefixRef = in.PrefixRef
+	out.NetworkPolicyRef = in.NetworkPolicyRef
 	return nil
 }
 
@@ -253,6 +257,7 @@ func autoConvert_ironcore_InfrastructureStatus_To_v1alpha1_InfrastructureStatus(
 	out.NetworkRef = in.NetworkRef
 	out.NATGatewayRef = in.NATGatewayRef
 	out.PrefixRef = in.PrefixRef
+	out.NetworkPolicyRef = in.NetworkPolicyRef
 	return nil
 }
 

--- a/pkg/apis/ironcore/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/ironcore/v1alpha1/zz_generated.deepcopy.go
@@ -9,6 +9,7 @@
 package v1alpha1
 
 import (
+	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -120,6 +121,11 @@ func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.NetworkPolicyRef != nil {
+		in, out := &in.NetworkPolicyRef, &out.NetworkPolicyRef
+		*out = new(commonv1alpha1.LocalUIDReference)
+		**out = **in
+	}
 	return
 }
 
@@ -148,6 +154,7 @@ func (in *InfrastructureStatus) DeepCopyInto(out *InfrastructureStatus) {
 	out.NetworkRef = in.NetworkRef
 	out.NATGatewayRef = in.NATGatewayRef
 	out.PrefixRef = in.PrefixRef
+	out.NetworkPolicyRef = in.NetworkPolicyRef
 	return
 }
 

--- a/pkg/apis/ironcore/zz_generated.deepcopy.go
+++ b/pkg/apis/ironcore/zz_generated.deepcopy.go
@@ -9,6 +9,7 @@
 package ironcore
 
 import (
+	v1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -120,6 +121,11 @@ func (in *InfrastructureConfig) DeepCopyInto(out *InfrastructureConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.NetworkPolicyRef != nil {
+		in, out := &in.NetworkPolicyRef, &out.NetworkPolicyRef
+		*out = new(v1alpha1.LocalUIDReference)
+		**out = **in
+	}
 	return
 }
 
@@ -148,6 +154,7 @@ func (in *InfrastructureStatus) DeepCopyInto(out *InfrastructureStatus) {
 	out.NetworkRef = in.NetworkRef
 	out.NATGatewayRef = in.NATGatewayRef
 	out.PrefixRef = in.PrefixRef
+	out.NetworkPolicyRef = in.NetworkPolicyRef
 	return
 }
 

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -37,6 +37,10 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extension
 		return fmt.Errorf("failed to delete infrastructure: %w", err)
 	}
 
+	if err := a.deleteNetworkPolicy(ctx, ironcoreClient, namespace, cluster); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed to delete infrastructure: %w", err)
+	}
+
 	if err := a.deleteNetwork(ctx, ironcoreClient, namespace, cluster); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("failed to delete infrastructure: %w", err)
 	}
@@ -77,4 +81,14 @@ func (a *actuator) deleteNetwork(ctx context.Context, ironcoreClient client.Clie
 		},
 	}
 	return ironcoreClient.Delete(ctx, network)
+}
+
+func (a *actuator) deleteNetworkPolicy(ctx context.Context, ironcoreClient client.Client, namespace string, cluster *controller.Cluster) error {
+	networkPolicy := &networkingv1alpha1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      generateResourceNameFromCluster(cluster),
+		},
+	}
+	return ironcoreClient.Delete(ctx, networkPolicy)
 }

--- a/pkg/controller/infrastructure/actuator_delete_test.go
+++ b/pkg/controller/infrastructure/actuator_delete_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("Infrastructure Reconcile", func() {
 	ns := SetupTest()
 
-	FIt("should ensure that the network, networkpolicy, natgateway and prefix is being deleted", func(ctx SpecContext) {
+	It("should ensure that the network, networkpolicy, natgateway and prefix is being deleted", func(ctx SpecContext) {
 		By("getting the cluster object")
 		cluster, err := extensionscontroller.GetCluster(ctx, k8sClient, ns.Name)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/infrastructure/actuator_delete_test.go
+++ b/pkg/controller/infrastructure/actuator_delete_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("Infrastructure Reconcile", func() {
 	ns := SetupTest()
 
-	It("should ensure that the network, natgateway and prefix is being deleted", func(ctx SpecContext) {
+	FIt("should ensure that the network, networkpolicy, natgateway and prefix is being deleted", func(ctx SpecContext) {
 		By("getting the cluster object")
 		cluster, err := extensionscontroller.GetCluster(ctx, k8sClient, ns.Name)
 		Expect(err).NotTo(HaveOccurred())
@@ -63,6 +63,7 @@ var _ = Describe("Infrastructure Reconcile", func() {
 				Name:      generateResourceNameFromCluster(cluster),
 			},
 		}
+		Eventually(Get(network)).Should(Succeed())
 
 		By("expecting a nat gateway being created")
 		natGateway := &networkingv1alpha1.NATGateway{
@@ -71,6 +72,7 @@ var _ = Describe("Infrastructure Reconcile", func() {
 				Name:      generateResourceNameFromCluster(cluster),
 			},
 		}
+		Eventually(Get(natGateway)).Should(Succeed())
 
 		By("expecting a prefix being created")
 		prefix := &ipamv1alpha1.Prefix{
@@ -79,6 +81,16 @@ var _ = Describe("Infrastructure Reconcile", func() {
 				Name:      generateResourceNameFromCluster(cluster),
 			},
 		}
+		Eventually(Get(prefix)).Should(Succeed())
+
+		By("expecting a network policy being created")
+		networkPolicy := &networkingv1alpha1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      generateResourceNameFromCluster(cluster),
+			},
+		}
+		Eventually(Get(networkPolicy)).Should(Succeed())
 
 		By("deleting the infrastructure resource")
 		Expect(k8sClient.Delete(ctx, infra)).Should(Succeed())
@@ -91,5 +103,8 @@ var _ = Describe("Infrastructure Reconcile", func() {
 
 		By("waiting for the prefix to be gone")
 		Eventually(Get(prefix)).Should(Satisfy(apierrors.IsNotFound))
+
+		By("waiting for the network policy to be gone")
+		Eventually(Get(networkPolicy)).Should(Satisfy(apierrors.IsNotFound))
 	})
 })


### PR DESCRIPTION
# Proposed Changes

- Add default network policy for shoot with default ingress/egress
- Use label `extension.ironcore.dev/cluster-name` as `NetworkInterfaceSelector` while creating `NetworkPolicy` (Note same label is used while creating `NetworkInterface` in machine controller)
- Add testcases


Fixes #672 