### PR TITLE
Publish helm charts to ghcr.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 **/dev
 /bin
 /hack/tools/bin
+/artifacts
+images.txt
 
 cover.out
 *.coverprofile

--- a/charts/gardener-extension-admission-ironcore/charts/application/Chart.yaml
+++ b/charts/gardener-extension-admission-ironcore/charts/application/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart to deploy the gardener-extension-admission-ironcore application related resources
-name: application
+name: gardener-extension-admission-ironcore-application
 version: 0.1.0

--- a/charts/gardener-extension-admission-ironcore/charts/runtime/Chart.yaml
+++ b/charts/gardener-extension-admission-ironcore/charts/runtime/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart to deploy the gardener-extension-admission-ironcore runtime related resources
-name: runtime
+name: gardener-extension-admission-ironcore-runtime
 version: 0.1.0

--- a/hack/push-artifacts.sh
+++ b/hack/push-artifacts.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+charts=(
+  gardener-extension-provider-ironcore
+  gardener-extension-admission-ironcore/charts/application
+  gardener-extension-admission-ironcore/charts/runtime
+)
+
+helm_artifacts=artifacts/charts
+rm -rf "$helm_artifacts"
+mkdir -p "$helm_artifacts"
+cp -r charts/gardener-extension-* "$helm_artifacts"
+
+function image() {
+  grep "$1" images.txt
+}
+
+function image_repo() {
+  image "$1" | cut -d ':' -f 1
+}
+
+function image_tag() {
+  image "$1" | cut -d ':' -f 2-
+}
+
+function update_chart_values() {
+  for chart in charts/*; do
+    name=$(basename "$chart")
+    values_file="$helm_artifacts/$name/values.yaml"
+
+    if yq -e '. | has("image")' "$values_file" >/dev/null 2>&1; then
+      # update charts that have a ".image" field
+      yq -i "\
+        ( .image = \"$(image "$name")\" )\
+      " "$values_file"
+    elif yq -e '.global | has("image")' "$values_file" >/dev/null 2>&1; then
+      # update charts that have a ".global.image" field
+      yq -i "\
+        ( .global.image.repository = \"$(image_repo "$name")\" ) | \
+        ( .global.image.tag = \"$(image_tag "$name")\" )\
+      " "$values_file"
+    fi
+  done
+}
+
+# inject image references into chart values
+update_chart_values
+
+set -x
+# push to registry
+if [ "$PUSH" != "true" ] ; then
+  echo "Skip pushing artifacts because PUSH is not set to 'true'"
+  exit 0
+fi
+
+for chart in "${charts[@]}"; do
+  chart_name=$(yq -e .name "$helm_artifacts/$chart/Chart.yaml")
+  helm package "$helm_artifacts/$chart" --version "$TAG" -d "$helm_artifacts" >/dev/null 2>&1
+  helm push "$helm_artifacts/$chart_name-"* "oci://$REPO/charts"
+done


### PR DESCRIPTION
# Proposed Changes
This PR adds a script to push the helm charts of `gardener-extension-provider-ironcore` to `ghcr.io`.

Before publishing the charts, the script replaces the image repository and tag in `values.yaml` with those from the artifacts which have just been built before.
The destination of the charts are `<repo>/charts/<chart-name` which will result in these concrete charts

ghcr.io/ironcore-dev/charts/gardener-extension-provider-ironcore
ghcr.io/ironcore-dev/charts/gardener-extension-admission-ironcore-admission
ghcr.io/ironcore-dev/charts/gardener-extension-admission-ironcore-runtime

Similar to https://github.com/stackitcloud/gardener-extension-acl/pull/114 from @oliver-goetz

A new make target `images` has been introduced to build the images with `ko.build`.

Images and Helm charts can be build and pushed with `PUSH=true make artifacts`.

Fixes #725 