### PR TITLE
Add CloudProfile validation webhook

### DIFF
--- a/pkg/admission/validator/cloudprofile.go
+++ b/pkg/admission/validator/cloudprofile.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	ironcorevalidation "github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore/validation"
+)
+
+// NewCloudProfileValidator returns a new instance of a cloud profile validator.
+func NewCloudProfileValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &cloudProfile{
+		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+	}
+}
+
+type cloudProfile struct {
+	decoder runtime.Decoder
+}
+
+// Validate validates the given CloudProfile objects.
+func (cp *cloudProfile) Validate(_ context.Context, newObj, _ client.Object) error {
+	cloudProfile, ok := newObj.(*core.CloudProfile)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	providerConfigPath := field.NewPath("spec").Child("providerConfig")
+	if cloudProfile.Spec.ProviderConfig == nil {
+		return field.Required(providerConfigPath, "providerConfig must be set for Ironcore cloud profiles")
+	}
+
+	cpConfig, err := decodeCloudProfileConfig(cp.decoder, cloudProfile.Spec.ProviderConfig)
+	if err != nil {
+		return err
+	}
+
+	return ironcorevalidation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, providerConfigPath).ToAggregate()
+}

--- a/pkg/admission/validator/serialization.go
+++ b/pkg/admission/validator/serialization.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"github.com/gardener/gardener/extensions/pkg/util"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore"
+)
+
+func decodeCloudProfileConfig(decoder runtime.Decoder, config *runtime.RawExtension) (*ironcore.CloudProfileConfig, error) {
+	cloudProfileConfig := &ironcore.CloudProfileConfig{}
+	if err := util.Decode(decoder, config.Raw, cloudProfileConfig); err != nil {
+		return nil, err
+	}
+	return cloudProfileConfig, nil
+}

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -34,6 +34,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:     "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
 			NewShootValidator(mgr):         {{Obj: &core.Shoot{}}},
+			NewCloudProfileValidator(mgr):  {{Obj: &core.CloudProfile{}}},
 			NewSecretBindingValidator(mgr): {{Obj: &core.SecretBinding{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
@@ -53,6 +54,10 @@ func NewSecretsWebhook(mgr manager.Manager) (*extensionswebhook.Webhook, error) 
 		Path:     "/webhooks/validate/secrets",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
 			NewSecretValidator(): {{Obj: &corev1.Secret{}}},
+		},
+		Target: extensionswebhook.TargetSeed,
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{constants.LabelExtensionProviderTypePrefix + ironcore.Type: "true"},
 		},
 	})
 }

--- a/pkg/apis/ironcore/validation/cloudprofile.go
+++ b/pkg/apis/ironcore/validation/cloudprofile.go
@@ -6,11 +6,13 @@ package validation
 import (
 	"fmt"
 
+	"github.com/gardener/gardener/extensions/pkg/util"
 	gardenercore "github.com/gardener/gardener/pkg/apis/core"
-	gardenercorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	"k8s.io/utils/strings/slices"
 
 	apisironcore "github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore"
@@ -21,19 +23,12 @@ func ValidateCloudProfileConfig(cpConfig *apisironcore.CloudProfileConfig, machi
 	allErrs := field.ErrorList{}
 	machineImagesPath := fldPath.Child("machineImages")
 
-	for _, image := range machineImages {
-		var processed bool
-		for i, imageConfig := range cpConfig.MachineImages {
-			if image.Name == imageConfig.Name {
-				allErrs = append(allErrs, validateVersions(imageConfig.Versions, gardenercorehelper.ToExpirableVersions(image.Versions), machineImagesPath.Index(i).Child("versions"))...)
-				processed = true
-				break
-			}
-		}
-		if !processed && len(image.Versions) > 0 {
-			allErrs = append(allErrs, field.Required(machineImagesPath, fmt.Sprintf("must provide an image mapping for image %q", image.Name)))
-		}
+	// validate all provider images fields
+	for i, machineImage := range cpConfig.MachineImages {
+		idxPath := machineImagesPath.Index(i)
+		allErrs = append(allErrs, ValidateProviderMachineImage(idxPath, machineImage)...)
 	}
+	allErrs = append(allErrs, validateProviderImagesMapping(cpConfig.MachineImages, machineImages, field.NewPath("spec").Child("machineImages"))...)
 
 	if cpConfig.StorageClasses.Default != nil {
 		for _, msg := range apivalidation.NameIsDNSLabel(cpConfig.StorageClasses.Default.Name, false) {
@@ -50,26 +45,80 @@ func ValidateCloudProfileConfig(cpConfig *apisironcore.CloudProfileConfig, machi
 	return allErrs
 }
 
-func validateVersions(versionsConfig []apisironcore.MachineImageVersion, versions []gardenercore.ExpirableVersion, fldPath *field.Path) field.ErrorList {
+// ValidateProviderMachineImage validates a CloudProfileConfig MachineImages entry.
+func ValidateProviderMachineImage(validationPath *field.Path, machineImage apisironcore.MachineImages) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	for _, version := range versions {
-		var processed bool
-		for j, versionConfig := range versionsConfig {
-			jdxPath := fldPath.Index(j)
-			if version.Version == versionConfig.Version {
-				if len(versionConfig.Image) == 0 {
-					allErrs = append(allErrs, field.Required(jdxPath.Child("image"), "must provide an image"))
-				}
-				if !slices.Contains(v1beta1constants.ValidArchitectures, *versionConfig.Architecture) {
-					allErrs = append(allErrs, field.NotSupported(jdxPath.Child("architecture"), *versionConfig.Architecture, v1beta1constants.ValidArchitectures))
-				}
-				processed = true
-				break
-			}
+	if len(machineImage.Name) == 0 {
+		allErrs = append(allErrs, field.Required(validationPath.Child("name"), "must provide a name"))
+	}
+
+	if len(machineImage.Versions) == 0 {
+		allErrs = append(allErrs, field.Required(validationPath.Child("versions"), fmt.Sprintf("must provide at least one version for machine image %q", machineImage.Name)))
+	}
+	for j, version := range machineImage.Versions {
+		jdxPath := validationPath.Child("versions").Index(j)
+		if len(version.Version) == 0 {
+			allErrs = append(allErrs, field.Required(jdxPath.Child("version"), "must provide a version"))
 		}
-		if !processed {
-			allErrs = append(allErrs, field.Required(fldPath, fmt.Sprintf("must provide an image mapping for version %q", version.Version)))
+		if len(version.Image) == 0 {
+			allErrs = append(allErrs, field.Required(jdxPath.Child("image"), "must provide an image"))
+		}
+		versionArch := ptr.Deref(version.Architecture, v1beta1constants.ArchitectureAMD64)
+		if !slices.Contains(v1beta1constants.ValidArchitectures, versionArch) {
+			allErrs = append(allErrs, field.NotSupported(jdxPath.Child("architecture"), versionArch, v1beta1constants.ValidArchitectures))
+		}
+	}
+
+	return allErrs
+}
+
+// NewProviderImagesContext creates a new ImagesContext for provider images.
+func NewProviderImagesContext(providerImages []apisironcore.MachineImages) *util.ImagesContext[apisironcore.MachineImages, apisironcore.MachineImageVersion] {
+	return util.NewImagesContext(
+		utils.CreateMapFromSlice(providerImages, func(mi apisironcore.MachineImages) string { return mi.Name }),
+		func(mi apisironcore.MachineImages) map[string]apisironcore.MachineImageVersion {
+			return utils.CreateMapFromSlice(mi.Versions, func(v apisironcore.MachineImageVersion) string { return providerMachineImageKey(v) })
+		},
+	)
+}
+
+func providerMachineImageKey(v apisironcore.MachineImageVersion) string {
+	return VersionArchitectureKey(v.Version, ptr.Deref(v.Architecture, v1beta1constants.ArchitectureAMD64))
+}
+
+// VersionArchitectureKey returns a key for a version and architecture.
+func VersionArchitectureKey(version, architecture string) string {
+	return version + "-" + architecture
+}
+
+// verify that for each cp image a provider image exists
+func validateProviderImagesMapping(cpConfigImages []apisironcore.MachineImages, machineImages []gardenercore.MachineImage, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	providerImages := NewProviderImagesContext(cpConfigImages)
+
+	// for each image in the CloudProfile, check if it exists in the CloudProfileConfig
+	for idxImage, machineImage := range machineImages {
+		if len(machineImage.Versions) == 0 {
+			continue
+		}
+		machineImagePath := fldPath.Index(idxImage)
+		if _, existsInParent := providerImages.GetImage(machineImage.Name); !existsInParent {
+			allErrs = append(allErrs, field.Required(machineImagePath, fmt.Sprintf("must provide a provider image mapping for image %q", machineImage.Name)))
+			continue
+		}
+
+		// validate that for each version and architecture of an image in the cloud profile a
+		// corresponding provider specific image in the cloud profile config exists
+		for versionIdx, version := range machineImage.Versions {
+			imageVersionPath := machineImagePath.Child("versions").Index(versionIdx)
+			for _, expectedArchitecture := range version.Architectures {
+				if _, exists := providerImages.GetImageVersion(machineImage.Name, VersionArchitectureKey(version.Version, expectedArchitecture)); !exists {
+					allErrs = append(allErrs, field.Required(imageVersionPath,
+						fmt.Sprintf("must provide an image mapping for version %q and architecture: %s", version.Version, expectedArchitecture)))
+				}
+			}
 		}
 	}
 

--- a/pkg/apis/ironcore/validation/cloudprofile_test.go
+++ b/pkg/apis/ironcore/validation/cloudprofile_test.go
@@ -110,8 +110,9 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				errorList := ValidateCloudProfileConfig(cloudProfileConfig, machineImages, nilPath)
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("machineImages"),
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.machineImages[1]"),
+						"Detail": Equal("must provide a provider image mapping for image \"suse\""),
 					})),
 				))
 			})
@@ -119,21 +120,25 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			It("should forbid unsupported machine image version configuration", func() {
 				cloudProfileConfig.MachineImages[0].Versions[0].Image = ""
 				cloudProfileConfig.MachineImages[0].Versions[0].Architecture = ptr.To[string]("foo")
-				machineImages[0].Versions = append(machineImages[0].Versions, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "2.0.0"}})
+				machineImages[0].Versions = append(machineImages[0].Versions, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "2.0.0"}, Architectures: []string{"amd64"}})
+
 				errorList := ValidateCloudProfileConfig(cloudProfileConfig, machineImages, nilPath)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("machineImages[0].versions"),
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("machineImages[0].versions[0].image"),
+						"Detail": Equal("must provide an image"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("machineImages[0].versions[0].image"),
+						"Type":     Equal(field.ErrorTypeNotSupported),
+						"Field":    Equal("machineImages[0].versions[0].architecture"),
+						"BadValue": Equal("foo"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeNotSupported),
-						"Field": Equal("machineImages[0].versions[0].architecture"),
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.machineImages[0].versions[1]"),
+						"Detail": Equal("must provide an image mapping for version \"2.0.0\" and architecture: amd64"),
 					})),
 				))
 			})


### PR DESCRIPTION
Formerly, `ValidateCloudProfileConfig()` was not called. This PR adds the webhook configuration to validate `CloudProfile`s being created or updated.

The changes might be breaking, as for instance it was possible to create a `CloudProfile` with a machine image but no matching provider config.