### PR TITLE
Add `NamespacedCloudProfile` validation and mutation webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,12 +180,6 @@ docs: $(GEN_CRD_API_REFERENCE_DOCS) ## Run go generate to generate API reference
 	GODEBUG="gotypesalias=0" $(GEN_CRD_API_REFERENCE_DOCS) -api-dir ./pkg/apis/ironcore/v1alpha1 -config ./hack/api-reference/api.json -template-dir ./hack/api-reference/template -out-file ./hack/api-reference/api.md
 	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir ./pkg/apis/config/v1alpha1 -config ./hack/api-reference/config.json -template-dir ./hack/api-reference/template -out-file ./hack/api-reference/config.md
 
-.PHONY: verify
-verify: check format test
-
-.PHONY: verify-extended
-verify-extended: check-generate check format test-cov test-clean
-
 ##@ Tools
 
 ## Location to install dependencies to

--- a/pkg/admission/cmd/options.go
+++ b/pkg/admission/cmd/options.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/admission/mutator"
 	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/admission/validator"
 )
 
@@ -14,5 +15,6 @@ func GardenWebhookSwitchOptions() *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
 		webhookcmd.Switch(validator.Name, validator.New),
 		webhookcmd.Switch(validator.SecretsValidatorName, validator.NewSecretsWebhook),
+		webhookcmd.Switch(mutator.Name, mutator.New),
 	)
 }

--- a/pkg/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/admission/mutator/namespacedcloudprofile.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore/v1alpha1"
+)
+
+// NewNamespacedCloudProfileMutator returns a new instance of a NamespacedCloudProfile mutator.
+func NewNamespacedCloudProfileMutator(mgr manager.Manager) extensionswebhook.Mutator {
+	return &namespacedCloudProfile{
+		client:  mgr.GetClient(),
+		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+	}
+}
+
+type namespacedCloudProfile struct {
+	client  client.Client
+	decoder runtime.Decoder
+}
+
+// Mutate mutates the given NamespacedCloudProfile object.
+func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Object) error {
+	profile, ok := newObj.(*gardencorev1beta1.NamespacedCloudProfile)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	// Ignore NamespacedCloudProfiles being deleted and wait for core mutator to patch the status.
+	if profile.DeletionTimestamp != nil || profile.Generation != profile.Status.ObservedGeneration ||
+		profile.Spec.ProviderConfig == nil || profile.Status.CloudProfileSpec.ProviderConfig == nil {
+		return nil
+	}
+
+	specConfig := &v1alpha1.CloudProfileConfig{}
+	if _, _, err := p.decoder.Decode(profile.Spec.ProviderConfig.Raw, nil, specConfig); err != nil {
+		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile spec for '%s': %w", profile.Name, err)
+	}
+	statusConfig := &v1alpha1.CloudProfileConfig{}
+	if _, _, err := p.decoder.Decode(profile.Status.CloudProfileSpec.ProviderConfig.Raw, nil, statusConfig); err != nil {
+		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status for '%s': %w", profile.Name, err)
+	}
+
+	statusConfig.MachineImages = mergeMachineImages(specConfig.MachineImages, statusConfig.MachineImages)
+
+	modifiedStatusConfig, err := json.Marshal(statusConfig)
+	if err != nil {
+		return err
+	}
+	profile.Status.CloudProfileSpec.ProviderConfig.Raw = modifiedStatusConfig
+
+	return nil
+}
+
+func mergeMachineImages(specMachineImages, statusMachineImages []v1alpha1.MachineImages) []v1alpha1.MachineImages {
+	specImages := utils.CreateMapFromSlice(specMachineImages, func(mi v1alpha1.MachineImages) string { return mi.Name })
+	statusImages := utils.CreateMapFromSlice(statusMachineImages, func(mi v1alpha1.MachineImages) string { return mi.Name })
+	for _, specMachineImage := range specImages {
+		if _, exists := statusImages[specMachineImage.Name]; !exists {
+			statusImages[specMachineImage.Name] = specMachineImage
+		} else {
+			statusImageVersions := utils.CreateMapFromSlice(statusImages[specMachineImage.Name].Versions, func(v v1alpha1.MachineImageVersion) string { return v.Version })
+			specImageVersions := utils.CreateMapFromSlice(specImages[specMachineImage.Name].Versions, func(v v1alpha1.MachineImageVersion) string { return v.Version })
+			for _, version := range specImageVersions {
+				statusImageVersions[version.Version] = version
+			}
+
+			statusImages[specMachineImage.Name] = v1alpha1.MachineImages{
+				Name:     specMachineImage.Name,
+				Versions: slices.Collect(maps.Values(statusImageVersions)),
+			}
+		}
+	}
+	return slices.Collect(maps.Values(statusImages))
+}

--- a/pkg/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/admission/mutator/namespacedcloudprofile_test.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/extensions/pkg/util"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/admission/mutator"
+	api "github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore"
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore/install"
+)
+
+var _ = Describe("NamespacedCloudProfile Mutator", func() {
+	var (
+		fakeClient  client.Client
+		fakeManager manager.Manager
+		namespace   string
+		ctx         = context.Background()
+		decoder     runtime.Decoder
+
+		namespacedCloudProfileMutator extensionswebhook.Mutator
+		namespacedCloudProfile        *v1beta1.NamespacedCloudProfile
+	)
+
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		utilruntime.Must(install.AddToScheme(scheme))
+		utilruntime.Must(v1beta1.AddToScheme(scheme))
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+		fakeManager = &test.FakeManager{
+			Client: fakeClient,
+			Scheme: scheme,
+		}
+		namespace = "garden-dev"
+		decoder = serializer.NewCodecFactory(fakeManager.GetScheme(), serializer.EnableStrict).UniversalDecoder()
+
+		namespacedCloudProfileMutator = mutator.NewNamespacedCloudProfileMutator(fakeManager)
+		namespacedCloudProfile = &v1beta1.NamespacedCloudProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "profile-1",
+				Namespace: namespace,
+			},
+		}
+	})
+
+	Describe("#Mutate", func() {
+		It("should succeed for NamespacedCloudProfile without provider config", func() {
+			Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should skip if NamespacedCloudProfile is in deletion phase", func() {
+			namespacedCloudProfile.DeletionTimestamp = ptr.To(metav1.Now())
+			expectedProfile := namespacedCloudProfile.DeepCopy()
+
+			Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+			Expect(namespacedCloudProfile).To(DeepEqual(expectedProfile))
+		})
+
+		Describe("merge the provider configurations from a NamespacedCloudProfile and the parent CloudProfile", func() {
+			It("should correctly merge extended machineImages", func() {
+				namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.0","regions":[{"name":"eu1","ami":"ami-123"}]}]}
+]}`)}
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.1","regions":[{"name":"eu2","ami":"ami-124","architecture":"armhf"}]}]},
+  {"name":"image-2","versions":[{"version":"2.0","regions":[{"name":"eu3","ami":"ami-125"}]}]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				mergedConfig, err := decodeCloudProfileConfig(decoder, namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mergedConfig.MachineImages).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Name": Equal("image-1"),
+						"Versions": ContainElements(
+							api.MachineImageVersion{Version: "1.0", Architecture: ptr.To("amd64")},
+							api.MachineImageVersion{Version: "1.1", Architecture: ptr.To("armhf")},
+						),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Name":     Equal("image-2"),
+						"Versions": ContainElements(api.MachineImageVersion{Version: "2.0", Architecture: ptr.To("amd64")}),
+					}),
+				))
+			})
+		})
+	})
+})
+
+func decodeCloudProfileConfig(decoder runtime.Decoder, config *runtime.RawExtension) (*api.CloudProfileConfig, error) {
+	cloudProfileConfig := &api.CloudProfileConfig{}
+	if err := util.Decode(decoder, config.Raw, cloudProfileConfig); err != nil {
+		return nil, err
+	}
+	return cloudProfileConfig, nil
+}

--- a/pkg/admission/mutator/webhook.go
+++ b/pkg/admission/mutator/webhook.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator
+
+import (
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/ironcore"
+)
+
+const (
+	// Name is a name for a mutation webhook.
+	Name = "mutator"
+)
+
+var logger = log.Log.WithName("ironcore-mutator-webhook")
+
+// New creates a new webhook that mutates Shoot and NamespacedCloudProfile resources.
+func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger.Info("Setting up webhook", "name", Name)
+
+	return extensionswebhook.New(mgr, extensionswebhook.Args{
+		Provider: ironcore.Type,
+		Name:     Name,
+		Path:     "/webhooks/mutate",
+		Mutators: map[extensionswebhook.Mutator][]extensionswebhook.Type{
+			NewNamespacedCloudProfileMutator(mgr): {{Obj: &gardencorev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")}},
+		},
+		Target: extensionswebhook.TargetSeed,
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{constants.LabelExtensionProviderTypePrefix + ironcore.Type: "true"},
+		},
+	})
+}

--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/gardener/gardener/extensions/pkg/util"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	api "github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore"
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore/validation"
+)
+
+// NewNamespacedCloudProfileValidator returns a new instance of a namespaced cloud profile validator.
+func NewNamespacedCloudProfileValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &namespacedCloudProfile{
+		client:  mgr.GetClient(),
+		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
+	}
+}
+
+type namespacedCloudProfile struct {
+	client  client.Client
+	decoder runtime.Decoder
+}
+
+// Validate validates the given NamespacedCloudProfile objects.
+func (p *namespacedCloudProfile) Validate(ctx context.Context, newObj, _ client.Object) error {
+	profile, ok := newObj.(*core.NamespacedCloudProfile)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if profile.DeletionTimestamp != nil {
+		return nil
+	}
+
+	cpConfig := &api.CloudProfileConfig{}
+	if profile.Spec.ProviderConfig != nil {
+		var err error
+		cpConfig, err = decodeCloudProfileConfig(p.decoder, profile.Spec.ProviderConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	parentCloudProfile := profile.Spec.Parent
+	if parentCloudProfile.Kind != constants.CloudProfileReferenceKindCloudProfile {
+		return fmt.Errorf("parent reference must be of kind CloudProfile (unsupported kind: %s)", parentCloudProfile.Kind)
+	}
+	parentProfile := &gardencorev1beta1.CloudProfile{}
+	if err := p.client.Get(ctx, client.ObjectKey{Name: parentCloudProfile.Name}, parentProfile); err != nil {
+		return err
+	}
+
+	return p.validateNamespacedCloudProfileProviderConfig(cpConfig, profile.Spec, parentProfile.Spec).ToAggregate()
+}
+
+// validateNamespacedCloudProfileProviderConfig validates the CloudProfileConfig passed with a NamespacedCloudProfile.
+func (p *namespacedCloudProfile) validateNamespacedCloudProfileProviderConfig(providerConfig *api.CloudProfileConfig, profileSpec core.NamespacedCloudProfileSpec, parentSpec gardencorev1beta1.CloudProfileSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, p.validateMachineImages(providerConfig, profileSpec.MachineImages, parentSpec)...)
+
+	return allErrs
+}
+
+func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.CloudProfileConfig, machineImages []core.MachineImage, parentSpec gardencorev1beta1.CloudProfileSpec) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	machineImagesPath := field.NewPath("spec.providerConfig.machineImages")
+	for i, machineImage := range providerConfig.MachineImages {
+		idxPath := machineImagesPath.Index(i)
+		allErrs = append(allErrs, validation.ValidateProviderMachineImage(idxPath, machineImage)...)
+	}
+
+	profileImages := util.NewCoreImagesContext(machineImages)
+	parentImages := util.NewV1beta1ImagesContext(parentSpec.MachineImages)
+	providerImages := validation.NewProviderImagesContext(providerConfig.MachineImages)
+
+	for _, machineImage := range profileImages.Images {
+		// Check that for each new image version defined in the NamespacedCloudProfile, the image is also defined in the providerConfig.
+		_, existsInParent := parentImages.GetImage(machineImage.Name)
+		if _, existsInProvider := providerImages.GetImage(machineImage.Name); !existsInParent && !existsInProvider {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec.providerConfig.machineImages"),
+				fmt.Sprintf("machine image %s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name),
+			))
+			continue
+		}
+		for _, version := range machineImage.Versions {
+			_, existsInParent := parentImages.GetImageVersion(machineImage.Name, version.Version)
+			for _, expectedArchitecture := range version.Architectures {
+				if _, exists := providerImages.GetImageVersion(machineImage.Name, validation.VersionArchitectureKey(version.Version, expectedArchitecture)); !existsInParent && !exists {
+					allErrs = append(allErrs, field.Required(
+						field.NewPath("spec.providerConfig.machineImages"),
+						fmt.Sprintf("machine image version %s@%s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name, version.Version),
+					))
+				}
+			}
+		}
+	}
+	for imageIdx, machineImage := range providerConfig.MachineImages {
+		// Check that the machine image version is not already defined in the parent CloudProfile.
+		if _, exists := parentImages.GetImage(machineImage.Name); exists {
+			for versionIdx, version := range machineImage.Versions {
+				if _, exists := parentImages.GetImageVersion(machineImage.Name, version.Version); exists {
+					allErrs = append(allErrs, field.Forbidden(
+						field.NewPath("spec.providerConfig.machineImages").Index(imageIdx).Child("versions").Index(versionIdx),
+						fmt.Sprintf("machine image version %s@%s is already defined in the parent CloudProfile", machineImage.Name, version.Version),
+					))
+				}
+			}
+		}
+		// Check that the machine image version is defined in the NamespacedCloudProfile.
+		if _, exists := profileImages.GetImage(machineImage.Name); !exists {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec.providerConfig.machineImages").Index(imageIdx),
+				fmt.Sprintf("machine image %s is not defined in the NamespacedCloudProfile .spec.machineImages", machineImage.Name),
+			))
+			continue
+		}
+		for versionIdx, version := range machineImage.Versions {
+			profileImageVersion, exists := profileImages.GetImageVersion(machineImage.Name, version.Version)
+			if !exists {
+				allErrs = append(allErrs, field.Invalid(
+					field.NewPath("spec.providerConfig.machineImages").Index(imageIdx).Child("versions").Index(versionIdx),
+					fmt.Sprintf("%s@%s", machineImage.Name, version.Version),
+					"machine image version is not defined in the NamespacedCloudProfile",
+				))
+			}
+			providerConfigArchitecture := ptr.Deref(version.Architecture, constants.ArchitectureAMD64)
+			if !slices.Contains(profileImageVersion.Architectures, providerConfigArchitecture) {
+				allErrs = append(allErrs, field.Forbidden(
+					field.NewPath("spec.providerConfig.machineImages"),
+					fmt.Sprintf("machine image version %s@%s has an excess entry for architecture %q, which is not defined in the machineImages spec",
+						machineImage.Name, version.Version, providerConfigArchitecture),
+				))
+			}
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/admission/validator/namespacedcloudprofile_test.go
+++ b/pkg/admission/validator/namespacedcloudprofile_test.go
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+	"time"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/admission/validator"
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore/install"
+)
+
+var _ = Describe("NamespacedCloudProfile Validator", func() {
+	var (
+		fakeClient  client.Client
+		fakeManager manager.Manager
+		namespace   string
+		ctx         = context.Background()
+
+		namespacedCloudProfileValidator extensionswebhook.Validator
+		namespacedCloudProfile          *core.NamespacedCloudProfile
+		cloudProfile                    *v1beta1.CloudProfile
+	)
+
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		utilruntime.Must(install.AddToScheme(scheme))
+		utilruntime.Must(v1beta1.AddToScheme(scheme))
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+		fakeManager = &test.FakeManager{
+			Client: fakeClient,
+			Scheme: scheme,
+		}
+		namespace = "garden-dev"
+
+		namespacedCloudProfileValidator = validator.NewNamespacedCloudProfileValidator(fakeManager)
+		namespacedCloudProfile = &core.NamespacedCloudProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "profile-1",
+				Namespace: namespace,
+			},
+			Spec: core.NamespacedCloudProfileSpec{
+				Parent: core.CloudProfileReference{
+					Name: "cloud-profile",
+					Kind: "CloudProfile",
+				},
+			},
+		}
+		cloudProfile = &v1beta1.CloudProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cloud-profile",
+			},
+		}
+	})
+
+	Describe("#Validate", func() {
+		It("should succeed for NamespacedCloudProfile without provider config", func() {
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should succeed if NamespacedCloudProfile is in deletion phase", func() {
+			namespacedCloudProfile.DeletionTimestamp = ptr.To(metav1.Now())
+
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should succeed if the NamespacedCloudProfile correctly defines new machine images and types", func() {
+			cloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[{"name":"image-1","versions":[{"version":"1.0","image":"imgRef1"}]}]
+}`)}
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.1","image":"imgRef2"}]},
+  {"name":"image-2","versions":[{"version":"2.0","image":"imgRef3"}]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name:     "image-1",
+					Versions: []core.MachineImageVersion{{ExpirableVersion: core.ExpirableVersion{Version: "1.1"}, Architectures: []string{"amd64"}}},
+				},
+				{
+					Name:     "image-2",
+					Versions: []core.MachineImageVersion{{ExpirableVersion: core.ExpirableVersion{Version: "2.0"}, Architectures: []string{"amd64"}}},
+				},
+			}
+			namespacedCloudProfile.Spec.MachineTypes = []core.MachineType{
+				{Name: "type-2"},
+			}
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should succeed if the NamespacedCloudProfile sets an expiration date to an already existing machine image version", func() {
+			cloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+				{Name: "image-1", Versions: []v1beta1.MachineImageVersion{{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}}}},
+			}
+			cloudProfile.Spec.MachineTypes = []v1beta1.MachineType{{Name: "type-1"}}
+
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.0", ExpirationDate: &metav1.Time{Time: time.Now().Add(time.Hour)}}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
+		It("should fail for NamespacedCloudProfile with invalid parent kind", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig"
+}`)}
+			namespacedCloudProfile.Spec.Parent = core.CloudProfileReference{
+				Name: "cloud-profile",
+				Kind: "NamespacedCloudProfile",
+			}
+
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(MatchError(ContainSubstring("parent reference must be of kind CloudProfile")))
+		})
+
+		It("should fail for NamespacedCloudProfile trying to override an already existing machine image version", func() {
+			cloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+				{Name: "image-1", Versions: []v1beta1.MachineImageVersion{{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}}}},
+			}
+			cloudProfile.Spec.MachineTypes = []v1beta1.MachineType{{Name: "type-1"}}
+
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.0","image":"imgRef1"}]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.0"}, Architectures: []string{"amd64"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal("spec.providerConfig.machineImages[0].versions[0]"),
+				"Detail": Equal("machine image version image-1@1.0 is already defined in the parent CloudProfile"),
+			}))))
+		})
+
+		It("should fail for NamespacedCloudProfile specifying provider config without the according version in the spec.machineImages", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.1","image":"imgRef2"}]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.2"}, Architectures: []string{"amd64"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.2 is not defined in the NamespacedCloudProfile providerConfig"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("spec.providerConfig.machineImages[0].versions[0]"),
+				"BadValue": Equal("image-1@1.1"),
+				"Detail":   Equal("machine image version is not defined in the NamespacedCloudProfile"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1 has an excess entry for architecture \"amd64\", which is not defined in the machineImages spec"),
+			}))))
+		})
+
+		It("should fail for NamespacedCloudProfile specifying new spec.machineImages without the according version and architecture entries in the provider config", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[
+	{"version":"1.1","image":"image-id-1","architecture":"arm64"},
+	{"version":"1.1","image":"image-id-2","architecture":"amd64"},
+    {"version":"1.1-fallback","image":"image-id-3"}
+  ]}
+]
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1"}, Architectures: []string{"amd64", "arm64"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1-fallback"}, Architectures: []string{"arm64"}},
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.1-missing"}, Architectures: []string{"arm64"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1-fallback is not defined in the NamespacedCloudProfile providerConfig"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1-missing is not defined in the NamespacedCloudProfile providerConfig"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1-fallback has an excess entry for architecture \"amd64\", which is not defined in the machineImages spec"),
+			}))))
+		})
+
+		It("should fail for NamespacedCloudProfile specifying new spec.machineImages without the according version in the provider config", func() {
+			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"ironcore.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig"
+}`)}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-3",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "3.0"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+
+			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
+			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image image-3 is not defined in the NamespacedCloudProfile providerConfig"),
+			}))))
+		})
+	})
+})

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -33,9 +33,10 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Name:     Name,
 		Path:     "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator(mgr):         {{Obj: &core.Shoot{}}},
-			NewCloudProfileValidator(mgr):  {{Obj: &core.CloudProfile{}}},
-			NewSecretBindingValidator(mgr): {{Obj: &core.SecretBinding{}}},
+			NewShootValidator(mgr):                  {{Obj: &core.Shoot{}}},
+			NewCloudProfileValidator(mgr):           {{Obj: &core.CloudProfile{}}},
+			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
+			NewSecretBindingValidator(mgr):          {{Obj: &core.SecretBinding{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{


### PR DESCRIPTION
# Proposed Changes

- add validation webhook for `NamespacedCloudProfile`s
- add mutation webhook for `NamespacedCloudProfile`s to inject custom machine images and versions

Part of https://github.com/gardener/gardener/issues/9504.