### PR TITLE
Bump golangci-lint to v2.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.4


### PR DESCRIPTION
# Proposed Changes

- Bump golangci-lint to v2.4
