### PR TITLE
Add `CredentialsBinding` validation via admission webhook

### DIFF
--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/security"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	ironcorevalidation "github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/apis/ironcore/validation"
+)
+
+type credentialsBinding struct {
+	apiReader client.Reader
+}
+
+// NewCredentialsBindingValidator returns a new instance of a credentials binding validator.
+func NewCredentialsBindingValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &credentialsBinding{
+		apiReader: mgr.GetAPIReader(),
+	}
+}
+
+// Validate checks whether the given CredentialsBinding refers to a Secret with a valid ironcore service account.
+func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj client.Object) error {
+	credentialsBinding, ok := newObj.(*security.CredentialsBinding)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if oldObj != nil {
+		_, ok := oldObj.(*security.CredentialsBinding)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", oldObj)
+		}
+
+		// The relevant fields of the credentials binding are immutable so we can exit early on update
+		return nil
+	}
+
+	var (
+		credentialsKey = client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
+	)
+	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets
+	// under the hood. The latter increases the memory usage of the component.
+	switch {
+	case credentialsBinding.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() && credentialsBinding.CredentialsRef.Kind == "Secret":
+		secret := &corev1.Secret{}
+		if err := cb.apiReader.Get(ctx, credentialsKey, secret); err != nil {
+			return err
+		}
+
+		return ironcorevalidation.ValidateCloudProviderSecret(secret)
+	default:
+		return fmt.Errorf("unsupported credentials reference: version %q, kind %q", credentialsBinding.CredentialsRef.APIVersion, credentialsBinding.CredentialsRef.Kind)
+	}
+}

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/security"
+	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore/pkg/admission/validator"
+)
+
+var _ = Describe("CredentialsBinding validator", func() {
+	Describe("#Validate", func() {
+		const (
+			namespace = "garden-dev"
+			name      = "my-provider-account"
+		)
+
+		var (
+			credentialsBindingValidator extensionswebhook.Validator
+
+			ctrl      *gomock.Controller
+			mgr       *mockmanager.MockManager
+			apiReader *mockclient.MockReader
+
+			ctx                = context.TODO()
+			credentialsBinding *security.CredentialsBinding
+
+			fakeErr = fmt.Errorf("fake err")
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+
+			mgr = mockmanager.NewMockManager(ctrl)
+
+			apiReader = mockclient.NewMockReader(ctrl)
+			mgr.EXPECT().GetAPIReader().Return(apiReader)
+
+			credentialsBindingValidator = validator.NewCredentialsBindingValidator(mgr)
+
+			credentialsBinding = &security.CredentialsBinding{
+				CredentialsRef: corev1.ObjectReference{
+					Name:       name,
+					Namespace:  namespace,
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should return err when obj is not a CredentialsBinding", func() {
+			err := credentialsBindingValidator.Validate(ctx, &corev1.Secret{}, nil)
+			Expect(err).To(MatchError("wrong object type *v1.Secret"))
+		})
+
+		It("should return err when oldObj is not a CredentialsBinding", func() {
+			err := credentialsBindingValidator.Validate(ctx, &security.CredentialsBinding{}, &corev1.Secret{})
+			Expect(err).To(MatchError("wrong object type *v1.Secret for old object"))
+		})
+
+		It("should return err if the CredentialsBinding references unknown credentials type", func() {
+			credentialsBinding.CredentialsRef.APIVersion = "unknown"
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(MatchError(errors.New(`unsupported credentials reference: version "unknown", kind "Secret"`)))
+		})
+
+		It("should return err if it fails to get the corresponding Secret", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(MatchError(fakeErr))
+		})
+
+		It("should return err when the corresponding Secret is not valid", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						"foo": []byte("bar"),
+					}}
+					*obj = *secret
+					return nil
+				})
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should succeed when the corresponding Secret is valid", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						"namespace": []byte("default"),
+						"token":     []byte("abcd"),
+						"username":  []byte("admin"),
+					}}
+
+					*obj = *secret
+					return nil
+				})
+
+			Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)).To(Succeed())
+		})
+
+		It("should return nil when the CredentialsBinding did not change", func() {
+			old := credentialsBinding.DeepCopy()
+
+			Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, old)).To(Succeed())
+		})
+	})
+})

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -7,6 +7,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/security"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,6 +38,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			NewCloudProfileValidator(mgr):           {{Obj: &core.CloudProfile{}}},
 			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
 			NewSecretBindingValidator(mgr):          {{Obj: &core.SecretBinding{}}},
+			NewCredentialsBindingValidator(mgr):     {{Obj: &security.CredentialsBinding{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{


### PR DESCRIPTION
# Proposed Changes

- Add `CredentialsBinding` validation: `SecretBinding` has been deprecated in favor of `CredentialsBinding` in gardener v1.127.0 (see [here](https://github.com/gardener/gardener/pull/12804)). This PR adds support for `CredentialsBinding` to allow migrating (see [docs](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md)).

(This is related to [GEP-26](https://github.com/gardener/gardener/blob/master/docs/proposals/26-workload-identity.md))