### PR TITLE
Default to overlay enabled when shoot networking config is nil

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -411,7 +411,7 @@ func getCCMChartValues(
 
 func isOverlayEnabled(networking *gardencorev1beta1.Networking) (bool, error) {
 	if networking == nil || networking.ProviderConfig == nil {
-		return false, nil
+		return true, nil
 	}
 
 	obj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, networking.ProviderConfig.Raw)
@@ -429,7 +429,7 @@ func isOverlayEnabled(networking *gardencorev1beta1.Networking) (bool, error) {
 		return false, err
 	}
 	if !ok {
-		return false, nil
+		return true, nil
 	}
 
 	return enabled, nil

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -497,6 +497,129 @@ var _ = Describe("Valueprovider Reconcile", func() {
 				},
 			}))
 		})
+
+		It("should not configure cloud routes when networking provider config is nil", func(ctx SpecContext) {
+			cp := &extensionsv1alpha1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "control-plane",
+					Namespace: ns.Name,
+				},
+				Spec: extensionsv1alpha1.ControlPlaneSpec{
+					Region: "foo",
+					SecretRef: corev1.SecretReference{
+						Name:      "my-infra-creds",
+						Namespace: ns.Name,
+					},
+					DefaultSpec: extensionsv1alpha1.DefaultSpec{
+						Type: ironcore.Type,
+						ProviderConfig: &runtime.RawExtension{
+							Raw: encode(&apisironcore.ControlPlaneConfig{
+								CloudControllerManager: &apisironcore.CloudControllerManagerConfig{
+									FeatureGates: map[string]bool{
+										"CustomResourceValidation": true,
+									},
+								},
+							}),
+						},
+					},
+					InfrastructureProviderStatus: &runtime.RawExtension{
+						Raw: encode(&apisironcore.InfrastructureStatus{
+							NetworkRef: v1alpha1.LocalUIDReference{
+								Name: "my-network",
+								UID:  "1234",
+							},
+						}),
+					},
+				},
+			}
+			providerCloudProfile := &apisironcore.CloudProfileConfig{
+				StorageClasses: apisironcore.StorageClasses{
+					Default: &apisironcore.StorageClass{
+						Name: "foo",
+						Type: "volumeTypeFoo",
+					},
+					Additional: []apisironcore.StorageClass{
+						{
+							Name: "bar",
+							Type: "volumeTypeBar",
+						},
+					},
+				},
+			}
+			providerCloudProfileJson, err := json.Marshal(providerCloudProfile)
+			Expect(err).NotTo(HaveOccurred())
+			cluster := &controller.Cluster{
+				CloudProfile: &gardencorev1beta1.CloudProfile{
+					Spec: gardencorev1beta1.CloudProfileSpec{
+						ProviderConfig: &runtime.RawExtension{
+							Raw: providerCloudProfileJson,
+						},
+					},
+				},
+				Shoot: &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: ns.Name,
+						Name:      "my-shoot",
+					},
+					Spec: gardencorev1beta1.ShootSpec{
+						Networking: &gardencorev1beta1.Networking{
+							Pods: ptr.To[string]("10.0.0.0/16"),
+						},
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.26.0",
+							VerticalPodAutoscaler: &gardencorev1beta1.VerticalPodAutoscaler{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			}
+
+			checksums := map[string]string{
+				ironcore.CloudProviderConfigName: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+			}
+			values, err := vp.GetControlPlaneChartValues(ctx, cp, cluster, fakeSecretsManager, checksums, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(values).To(Equal(map[string]interface{}{
+				"global": map[string]interface{}{
+					"genericTokenKubeconfigSecretName": "generic-token-kubeconfig",
+				},
+				"cloud-controller-manager": map[string]interface{}{
+					"enabled":     true,
+					"replicas":    1,
+					"clusterName": ns.Name,
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-cloud-provider-config": "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
+					},
+					"podLabels": map[string]interface{}{
+						"maintenance.gardener.cloud/restart": "true",
+					},
+					"tlsCipherSuites": []string{
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+						"TLS_AES_128_GCM_SHA256",
+						"TLS_AES_256_GCM_SHA384",
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+						"TLS_CHACHA20_POLY1305_SHA256",
+						"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+						"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+					},
+					"secrets": map[string]interface{}{
+						"server": "cloud-controller-manager-server",
+					},
+					"featureGates": map[string]bool{
+						"CustomResourceValidation": true,
+					},
+					"podNetwork":           "10.0.0.0/16",
+					"configureCloudRoutes": false,
+				},
+				"csi-driver-controller": map[string]interface{}{
+					"enabled":  true,
+					"replicas": 1,
+				},
+			}))
+		})
 	})
 })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control plane default overlay networking behavior. Overlay functionality now defaults to enabled when configuration is not explicitly provided or is incomplete, rather than defaulting to disabled. This correction ensures proper networking behavior for standard deployments without explicit overlay configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->