### PR TITLE
Make `isOverlayEnabled` more resilient

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -5,6 +5,7 @@ package controlplane
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -26,7 +27,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	autoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -414,25 +414,21 @@ func isOverlayEnabled(networking *gardencorev1beta1.Networking) (bool, error) {
 		return true, nil
 	}
 
-	obj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, networking.ProviderConfig.Raw)
-	if err != nil {
-		return false, err
+	detectOverlay := &struct {
+		Overlay *struct {
+			Enabled bool `json:"enabled"`
+		} `json:"overlay,omitempty"`
+	}{}
+	if err := json.Unmarshal(networking.ProviderConfig.Raw, detectOverlay); err != nil {
+		return false, fmt.Errorf("failed to unmarshal network provider config: %w", err)
 	}
 
-	u, ok := obj.(*unstructured.Unstructured)
-	if !ok {
-		return false, fmt.Errorf("object %T is not an unstructured.Unstructured", obj)
+	overlay := detectOverlay.Overlay
+	if overlay == nil {
+		return false, nil
 	}
 
-	enabled, ok, err := unstructured.NestedBool(u.UnstructuredContent(), "overlay", "enabled")
-	if err != nil {
-		return false, err
-	}
-	if !ok {
-		return true, nil
-	}
-
-	return enabled, nil
+	return overlay.Enabled, nil
 }
 
 // getCSIControllerChartValues collects and returns the CSIController chart values.

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -416,7 +416,6 @@ var _ = Describe("Valueprovider Reconcile", func() {
 			providerCloudProfileJson, err := json.Marshal(providerCloudProfile)
 			Expect(err).NotTo(HaveOccurred())
 			networkProviderConfig := &unstructured.Unstructured{Object: map[string]any{
-				"kind":       "FooNetworkConfig",
 				"apiVersion": "v1alpha1",
 				"overlay": map[string]any{
 					"enabled": false,


### PR DESCRIPTION
Currently, e.g. missing provider kinds lead to `isOverlayEnabled` failing which causes shoots to be permanently stuck in deletion.

This change addresses this by doing a more lenient struct-based detection of whether the overlay network is enabled or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal configuration parsing efficiency in the control plane component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/gardener-extension-provider-ironcore/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->