### PR TITLE
Remove retired Go Report card badge


### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # [Gardener Extension for IronCore provider](https://gardener.cloud)
 
 [![REUSE status](https://api.reuse.software/badge/github.com/ironcore-dev/gardener-extension-provider-ironcore)](https://api.reuse.software/info/github.com/ironcore-dev/gardener-extension-provider-ironcore)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ironcore-dev/gardener-extension-provider-ironcore)](https://goreportcard.com/report/github.com/ironcore-dev/gardener-extension-provider-ironcore)
 [![GitHub License](https://img.shields.io/static/v1?label=License&message=Apache-2.0&color=blue)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://makeapullrequest.com)
 


### PR DESCRIPTION
Remove retired Go Report card badge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README badges by replacing the Go Report Card badge with a REUSE status badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->