### PR TITLE
Remove deprecated `VolumeSpec.Image` usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/imdario/mergo v0.3.16
 	github.com/ironcore-dev/controller-utils v0.12.0
-	github.com/ironcore-dev/ironcore v0.4.3
+	github.com/ironcore-dev/ironcore v0.4.4-0.20260713135223-851e1ddf89a6
 	github.com/ironcore-dev/vgopath v0.1.11
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ironcore-dev/controller-utils v0.12.0 h1:0OBUzV+Zkh6K+2h4LtqAjWru19/5d3ucuUK5qMzt1rs=
 github.com/ironcore-dev/controller-utils v0.12.0/go.mod h1:LHSeOLcIbPIkSiryKpZ30E/zDSWHTnkZD4w69+kPdMw=
-github.com/ironcore-dev/ironcore v0.4.3 h1:G3TmR4r3LtbmakMkxDa2pPlLCmxAfGVBEdy+QVyxl8Q=
-github.com/ironcore-dev/ironcore v0.4.3/go.mod h1:vFpdcyC4QD7o3j01lpux12NET6vNPDAq3hzrFOY9QOc=
+github.com/ironcore-dev/ironcore v0.4.4-0.20260713135223-851e1ddf89a6 h1:H1b+otbCys9nBaL3KjFkAOW/5mLO7gnY91jk21DwmCM=
+github.com/ironcore-dev/ironcore v0.4.4-0.20260713135223-851e1ddf89a6/go.mod h1:vFpdcyC4QD7o3j01lpux12NET6vNPDAq3hzrFOY9QOc=
 github.com/ironcore-dev/vgopath v0.1.11 h1:/ma2k8VeZiYsIO+1vZcbyJ7MWJuh5MPZkogbe14Za6E=
 github.com/ironcore-dev/vgopath v0.1.11/go.mod h1:VoFYVigURzkhWukXTA6IQ9pG822O4HHhUVEWzJZkaU4=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -222,7 +222,11 @@ func generateMachine(namespace string, bastionConfig *controllerconfig.BastionCo
 									Resources: corev1alpha1.ResourceList{
 										corev1alpha1.ResourceStorage: resource.MustParse("10Gi"),
 									},
-									Image: bastionConfig.Image,
+									DataSource: storagev1alpha1.VolumeDataSource{
+										OSImage: &storagev1alpha1.OSDataSource{
+											Image: bastionConfig.Image,
+										},
+									},
 								},
 							},
 						},

--- a/pkg/controller/bastion/actuator_reconcile_test.go
+++ b/pkg/controller/bastion/actuator_reconcile_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Bastion Host Reconcile", func() {
 			HaveField("Spec.Volumes", ContainElement(SatisfyAll(
 				HaveField("Name", "root"),
 				HaveField("VolumeSource.Ephemeral.VolumeTemplate.Spec.VolumeClassRef.Name", "my-volume-class"),
-				HaveField("VolumeSource.Ephemeral.VolumeTemplate.Spec.Image", "my-image"),
+				HaveField("VolumeSource.Ephemeral.VolumeTemplate.Spec.DataSource.OSImage.Image", "my-image"),
 				HaveField("VolumeSource.Ephemeral.VolumeTemplate.Spec.Resources", Equal(corev1alpha1.ResourceList{
 					corev1alpha1.ResourceStorage: resource.MustParse("10Gi"),
 				})),


### PR DESCRIPTION
## Proposed Changes

- Remove use of the deprecated IronCore `VolumeSpec.Image` field when creating bastion Machines ([#1498](https://github.com/ironcore-dev/ironcore/pull/1498)).
- Map bastion OS image via `dataSource.osImage` instead.
- Bump `github.com/ironcore-dev/ironcore` to `v0.4.4-0.20260713135223-851e1ddf89a6` (post-[#1498](https://github.com/ironcore-dev/ironcore/pull/1498)).

Ref https://github.com/ironcore-dev/ironcore/issues/1495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bastion host machine provisioning to use the current operating system image configuration.
  * Improved compatibility with the latest infrastructure component version.
* **Tests**
  * Updated validation to confirm that bastion machines receive the expected operating system image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->